### PR TITLE
Global var pollution in Compressor/Expo

### DIFF
--- a/js/effects/compressor.js
+++ b/js/effects/compressor.js
@@ -8,7 +8,7 @@
  * @param {number} gain (Optional) Gain factor (1.0 - 2.0).
 */
 function Compressor(sampleRate, scaleBy, gain){
-    var self    = this;
+    var self    = this,
         sample  = 0.0;
     self.sampleRate = sampleRate;
     self.scale = scaleBy || 1;

--- a/js/effects/extra.js
+++ b/js/effects/extra.js
@@ -15,7 +15,7 @@ audioLib.Capper = function(sampleRate, cap){
 };
 
 audioLib.Expo = function(sampleRate, param){
-	var	self	= this;
+	var	self	= this,
 		sample	= 0.0;
 	self.sampleRate = sampleRate;
 	self.param = param || 0.8;

--- a/tests/compressor.html
+++ b/tests/compressor.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <title>audiolib.js | Compressor Test</title>
         <script src="../lib/audiolib.js"></script>
-        <script src="../js/effects/extra.js"></script>
         <script>
 (function(){
 


### PR DESCRIPTION
Whoops, let a global slip through there.  Fixed it in Compressor and in Expo (where I copied the skeleton from)
