### PR TITLE
#20 bugfix and new Band-Pass Biquad Filter

### DIFF
--- a/js/effects/biquad.js
+++ b/js/effects/biquad.js
@@ -1,0 +1,108 @@
+// Adapted from http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt
+
+/**
+ * Parent constructor for Biquad Filter Effects
+ * 
+ * @constructor
+ * @this {BiquadFilter}
+ * @param {number} samplerate Sample Rate (hz).
+ * @param {number} a0 (Optional) Bit resolution of output signal. Defaults to 8.
+*/
+function BiquadFilter(sampleRate, a0, a1, a2, b1, b2){
+    var self    = this,
+        sample  = 0.0;
+    self.inputs     = [0,0];
+    self.outputs    = [0,0];
+    self.sampleRate = sampleRate;
+    self.coefs      = { a0:a0, a1:a1, a2:a2, b1:b1, b2:b2 };
+    
+    self.pushSample = function(s){
+        var c = self.coefs,
+            i = self.inputs,
+            o = self.outputs;
+        sample = c.a0 * s + c.a1 * i[0] + c.a2 * i[1] - c.b1 * o[0] - c.b2 * o[1];
+        i.pop();
+        i.unshift(s);
+        o.pop();
+        o.unshift(sample);
+        
+        return sample;
+    };
+    self.getMix = function(){
+        return sample;
+    };
+    
+    self.reset = function(){
+        self.inputs = self.outputs = [0,0];
+    };
+
+}
+
+/**
+ * Creates a Biquad Low-Pass Filter Effect
+ * 
+ * @constructor
+ * @this {BiquadFilter}
+ * @param {number} samplerate Sample Rate (hz).
+ * @param {number} cutoff Low-pass cutoff frequency (hz).
+ * @param {number} Q Filter Q-factor (Q<0.5 filter underdamped, Q>0.5 filter overdamped)
+*/
+BiquadFilter.LowPass = function(sampleRate, cutoff, Q){
+    var w0      = 2* Math.PI*cutoff/sampleRate,
+        cosw0   = Math.cos(w0),
+        sinw0   = Math.sin(w0),
+        alpha   = sinw0/(2*Q),
+        b0      =  (1 - cosw0)/2,
+        b1      =   1 - cosw0,
+        b2      =   b0,
+        a0      =   1 + alpha,
+        a1      =  -2*cosw0,
+        a2      =   1 - alpha;
+    return new BiquadFilter(sampleRate, b0/a0, b1/a0, b2/a0, a1/a0, a2/a0);
+}
+
+/**
+ * Creates a Biquad High-Pass Filter Effect
+ * 
+ * @constructor
+ * @this {BiquadFilter}
+ * @param {number} samplerate Sample Rate (hz).
+ * @param {number} cutoff High-pass cutoff frequency (hz).
+ * @param {number} Q Filter Q-factor (Q<0.5 filter underdamped, Q>0.5 filter overdamped)
+*/
+BiquadFilter.HighPass = function(sampleRate, cutoff, Q){
+    var w0      = 2* Math.PI*cutoff/sampleRate,
+        cosw0   = Math.cos(w0),
+        sinw0   = Math.sin(w0),
+        alpha   = sinw0/(2*Q),
+        b0      =  (1 + cosw0)/2,
+        b1      = -(1 + cosw0),
+        b2      =   b0,
+        a0      =   1 + alpha,
+        a1      =  -2*cosw0,
+        a2      =   1 - alpha;
+    return new audioLib.BiquadFilter(sampleRate, b0/a0, b1/a0, b2/a0, a1/a0, a2/a0);
+}
+
+/**
+ * Creates a Biquad All-Pass Filter Effect
+ * 
+ * @constructor
+ * @this {BiquadFilter}
+ * @param {number} samplerate Sample Rate (hz).
+ * @param {number} f0 Significant frequency: filter will cause a phase shift of 180deg at f0 (hz).
+ * @param {number} Q Filter Q-factor (Q<0.5 filter underdamped, Q>0.5 filter overdamped)
+*/
+BiquadFilter.AllPass = function(sampleRate, f0, Q){
+    var w0      = 2* Math.PI*f0/sampleRate,
+        cosw0   = Math.cos(w0),
+        sinw0   = Math.sin(w0),
+        alpha   = sinw0/(2*Q),
+        b0      =  1 - alpha,
+        b1      = -2*cosw0,
+        b2      =  1 + alpha,
+        a0      =  b2,
+        a1      =  b1,
+        a2      =  b0;
+    return new audioLib.BiquadFilter(sampleRate, b0/a0, b1/a0, b2/a0, a1/a0, a2/a0);
+}

--- a/js/effects/biquad.js
+++ b/js/effects/biquad.js
@@ -108,7 +108,15 @@ BiquadFilter.AllPass = function(sampleRate, f0, Q){
     return new audioLib.BiquadFilter(sampleRate, b0/a0, b1/a0, b2/a0, a1/a0, a2/a0);
 }
 
-//0db Peak Gain BPF
+/**
+ * Creates a Biquad Band-Pass Filter Effect
+ * 
+ * @constructor
+ * @this {BiquadFilter}
+ * @param {number} samplerate Sample Rate (hz).
+ * @param {number} centerFreq Center frequency of filter: 0dB gain at center peak
+ * @param {number} bandwidthInOctaves Bandwitdth of the filter (between -3dB points), specified in octaves
+*/
 BiquadFilter.BandPass = function(sampleRate, centerFreq, bandwidthInOctaves){
     var w0      = 2* Math.PI*centerFreq/sampleRate,
         cosw0   = Math.cos(w0),

--- a/js/effects/biquad.js
+++ b/js/effects/biquad.js
@@ -33,7 +33,8 @@ function BiquadFilter(sampleRate, a0, a1, a2, b1, b2){
     };
     
     self.reset = function(){
-        self.inputs = self.outputs = [0,0];
+        self.inputs = [0,0];
+        self.outputs = [0,0];
     };
 
 }
@@ -109,16 +110,16 @@ BiquadFilter.AllPass = function(sampleRate, f0, Q){
 
 //0db Peak Gain BPF
 BiquadFilter.BandPass = function(sampleRate, centerFreq, bandwidthInOctaves){
-    var w0      = 2* Math.PI*fc/sampleRate,
+    var w0      = 2* Math.PI*centerFreq/sampleRate,
         cosw0   = Math.cos(w0),
         sinw0   = Math.sin(w0),
-        toSinh  = Math.log(2)/2 * bandWidthInOctaves * w0/sinw0,
+        toSinh  = Math.log(2)/2 * bandwidthInOctaves * w0/sinw0,
         alpha   = sinw0*(Math.exp(toSinh) - Math.exp(-toSinh))/2,
         b0      =  alpha,
         b1      =  0,
         b2      = -alpha,
         a0      =  1 + alpha,
-        a1      = -2*cos(w0),
+        a1      = -2*cosw0,
         a2      =  1 - alpha;
     return new audioLib.BiquadFilter(sampleRate, b0/a0, b1/a0, b2/a0, a1/a0, a2/a0);
 }

--- a/js/effects/biquad.js
+++ b/js/effects/biquad.js
@@ -106,3 +106,19 @@ BiquadFilter.AllPass = function(sampleRate, f0, Q){
         a2      =  b0;
     return new audioLib.BiquadFilter(sampleRate, b0/a0, b1/a0, b2/a0, a1/a0, a2/a0);
 }
+
+//0db Peak Gain BPF
+BiquadFilter.BandPass = function(sampleRate, centerFreq, bandwidthInOctaves){
+    var w0      = 2* Math.PI*fc/sampleRate,
+        cosw0   = Math.cos(w0),
+        sinw0   = Math.sin(w0),
+        toSinh  = Math.log(2)/2 * bandWidthInOctaves * w0/sinw0,
+        alpha   = sinw0*(Math.exp(toSinh) - Math.exp(-toSinh))/2,
+        b0      =  alpha,
+        b1      =  0,
+        b2      = -alpha,
+        a0      =  1 + alpha,
+        a1      = -2*cos(w0),
+        a2      =  1 - alpha;
+    return new audioLib.BiquadFilter(sampleRate, b0/a0, b1/a0, b2/a0, a1/a0, a2/a0);
+}

--- a/js/effects/bitcrusher.js
+++ b/js/effects/bitcrusher.js
@@ -1,0 +1,24 @@
+// Adapted from http://www.musicdsp.org/archive.php?classid=4#139
+
+/**
+ * Creates a Bit Crusher Effect
+ * 
+ * @constructor
+ * @this {BitCrusher}
+ * @param {number} samplerate Sample Rate (hz).
+ * @param {number} bits (Optional) Bit resolution of output signal. Defaults to 8.
+*/
+function BitCrusher(sampleRate, bits){
+    var self    = this,
+        sample  = 0.0;
+    self.sampleRate = sampleRate;
+    self.resolution = bits ? Math.pow(2, bits-1) : Math.pow(2, 8-1); // Divided by 2 for signed samples (8bit range = 7bit signed)
+    self.pushSample = function(s){
+        sample = Math.floor(s*self.resolution+0.5)/self.resolution
+        return sample;
+    };
+    self.getMix = function(){
+        return sample;
+    };
+
+}

--- a/js/effects/compressor.js
+++ b/js/effects/compressor.js
@@ -8,7 +8,7 @@
  * @param {number} gain (Optional) Gain factor (1.0 - 2.0).
 */
 function Compressor(sampleRate, scaleBy, gain){
-    var self    = this;
+    var self    = this,
         sample  = 0.0;
     self.sampleRate = sampleRate;
     self.scale = scaleBy || 1;

--- a/js/effects/extra.js
+++ b/js/effects/extra.js
@@ -15,7 +15,7 @@ audioLib.Capper = function(sampleRate, cap){
 };
 
 audioLib.Expo = function(sampleRate, param){
-	var	self	= this;
+	var	self	= this,
 		sample	= 0.0;
 	self.sampleRate = sampleRate;
 	self.param = param || 0.8;

--- a/js/wrapper-end.js
+++ b/js/wrapper-end.js
@@ -23,7 +23,6 @@ audioLib.LP12Filter	= LP12Filter;
 //Geneneration
 audioLib.Oscillator	= Oscillator;
 audioLib.Sampler	= Sampler;
-audioLib.Tracker    = Tracker;
 
 function EffectClass(){
 }

--- a/js/wrapper-end.js
+++ b/js/wrapper-end.js
@@ -24,7 +24,6 @@ audioLib.LP12Filter	= LP12Filter;
 //Geneneration
 audioLib.Oscillator	= Oscillator;
 audioLib.Sampler	= Sampler;
-audioLib.Tracker    = Tracker;
 
 function EffectClass(){
 }
@@ -167,7 +166,7 @@ GeneratorClass.prototype = {
 	for (i=0; i<names.length; i++){
 		generators(names[i], audioLib[names[i]], audioLib[names[i]].prototype);
 	}
-}(['Oscillator', 'Sampler', 'Tracker']));
+}(['Oscillator', 'Sampler']));
 
 function Codec(name, codec){
 	var nameCamel = name[0].toUpperCase() + name.substr(1).toLowerCase();

--- a/js/wrapper-end.js
+++ b/js/wrapper-end.js
@@ -165,7 +165,7 @@ GeneratorClass.prototype = {
 	for (i=0; i<names.length; i++){
 		generators(names[i], audioLib[names[i]], audioLib[names[i]].prototype);
 	}
-}(['Oscillator', 'Sampler', 'Tracker']));
+}(['Oscillator', 'Sampler']));
 
 function Codec(name, codec){
 	var nameCamel = name[0].toUpperCase() + name.substr(1).toLowerCase();

--- a/js/wrapper-end.js
+++ b/js/wrapper-end.js
@@ -10,6 +10,7 @@ audioLib.StepSequencer		= StepSequencer;
 
 //Effects
 audioLib.AllPassFilter	= AllPassFilter;
+audioLib.BiquadFilter = BiquadFilter;
 audioLib.BitCrusher = BitCrusher;
 audioLib.Chorus		= Chorus;
 audioLib.Compressor = Compressor;
@@ -23,6 +24,7 @@ audioLib.LP12Filter	= LP12Filter;
 //Geneneration
 audioLib.Oscillator	= Oscillator;
 audioLib.Sampler	= Sampler;
+audioLib.Tracker    = Tracker;
 
 function EffectClass(){
 }
@@ -142,7 +144,7 @@ GeneratorClass.prototype = {
 	for (i=0; i<names.length; i++){
 		effects(names[i], audioLib[names[i]], audioLib[names[i]].prototype);
 	}
-}(['AllPassFilter', 'BitCrusher', 'Chorus', 'Compressor', 'Delay', 'Distortion', 'IIRFilter', 'LowPassFilter', 'LP12Filter']));
+}(['AllPassFilter', 'BiquadFilter', 'BitCrusher', 'Chorus', 'Compressor', 'Delay', 'Distortion', 'IIRFilter', 'LowPassFilter', 'LP12Filter']));
 
 (function(names, i){
 	function generators(name, effect, prototype){
@@ -165,7 +167,7 @@ GeneratorClass.prototype = {
 	for (i=0; i<names.length; i++){
 		generators(names[i], audioLib[names[i]], audioLib[names[i]].prototype);
 	}
-}(['Oscillator', 'Sampler']));
+}(['Oscillator', 'Sampler', 'Tracker']));
 
 function Codec(name, codec){
 	var nameCamel = name[0].toUpperCase() + name.substr(1).toLowerCase();

--- a/js/wrapper-end.js
+++ b/js/wrapper-end.js
@@ -10,6 +10,7 @@ audioLib.StepSequencer		= StepSequencer;
 
 //Effects
 audioLib.AllPassFilter	= AllPassFilter;
+audioLib.BitCrusher = BitCrusher;
 audioLib.Chorus		= Chorus;
 audioLib.Compressor = Compressor;
 audioLib.Delay		= Delay;
@@ -22,6 +23,7 @@ audioLib.LP12Filter	= LP12Filter;
 //Geneneration
 audioLib.Oscillator	= Oscillator;
 audioLib.Sampler	= Sampler;
+audioLib.Tracker    = Tracker;
 
 function EffectClass(){
 }
@@ -141,7 +143,7 @@ GeneratorClass.prototype = {
 	for (i=0; i<names.length; i++){
 		effects(names[i], audioLib[names[i]], audioLib[names[i]].prototype);
 	}
-}(['AllPassFilter', 'Chorus', 'Compressor', 'Delay', 'Distortion', 'IIRFilter', 'LowPassFilter', 'LP12Filter']));
+}(['AllPassFilter', 'BitCrusher', 'Chorus', 'Compressor', 'Delay', 'Distortion', 'IIRFilter', 'LowPassFilter', 'LP12Filter']));
 
 (function(names, i){
 	function generators(name, effect, prototype){
@@ -164,7 +166,7 @@ GeneratorClass.prototype = {
 	for (i=0; i<names.length; i++){
 		generators(names[i], audioLib[names[i]], audioLib[names[i]].prototype);
 	}
-}(['Oscillator', 'Sampler']));
+}(['Oscillator', 'Sampler', 'Tracker']));
 
 function Codec(name, codec){
 	var nameCamel = name[0].toUpperCase() + name.substr(1).toLowerCase();

--- a/tests/biquad.html
+++ b/tests/biquad.html
@@ -6,7 +6,7 @@
         <script>
 (function(){
     
-var hp, lp, ap;
+var filter;
 
 function plotPCM(buffer, channelCount){
     var canvas      = document.getElementById('c'),
@@ -22,7 +22,10 @@ function plotPCM(buffer, channelCount){
         osc2        = new audioLib.Oscillator(sampleRate, 3500),
         lpf         = new audioLib.BiquadFilter.LowPass(sampleRate, 1200, 0.6),
         apf         = new audioLib.BiquadFilter.AllPass(sampleRate, 300, 0.6),
-        hpf         = new audioLib.BiquadFilter.HighPass(sampleRate, 1200, 0.6);
+        hpf         = new audioLib.BiquadFilter.HighPass(sampleRate, 1200, 0.6),
+        bpfh        = new audioLib.BiquadFilter.BandPass(sampleRate, 3333, 1),
+        bpfl        = new audioLib.BiquadFilter.BandPass(sampleRate, 250, 1),
+        names       = {lp:lpf, hp:hpf, ap:apf, bph:bpfh, bpl:bpfl};
      
     function setup(){
         context.clearRect ( 0, 0, width, height);
@@ -60,39 +63,14 @@ function plotPCM(buffer, channelCount){
     }
     setup();
     
-    hp = function(){
-        // High-Pass Filter
+    filter = function(type, param){
         setup();
-
+        var filter = names[type];
+        filter.reset();
+        
         for(var i=0, max=sampleRate*plotTime; i<max; i++){
             
-            context.lineTo(i*xscale, halfHeight + hpf.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
-            osc.generate();
-            osc2.generate();
-        } 
-        context.stroke();
-    };
-    
-    lp = function(){
-        // Low-Pass Filter
-        setup();
-
-        for(var i=0, max=sampleRate*plotTime; i<max; i++){
-            
-            context.lineTo(i*xscale, halfHeight + lpf.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
-            osc.generate();
-            osc2.generate();
-        } 
-        context.stroke();
-    };
-    
-    ap = function(){
-        // All-Pass Filter
-        setup();
-
-        for(var i=0, max=sampleRate*plotTime; i<max; i++){
-            
-            context.lineTo(i*xscale, halfHeight + apf.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
+            context.lineTo(i*xscale, halfHeight + filter.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
             osc.generate();
             osc2.generate();
         } 
@@ -106,9 +84,11 @@ window.onload = function(){
         plotPCM();
     }, 2000);
 };
-window.hp = function(){hp()};
-window.lp = function(){lp()};
-window.ap = function(){ap()};
+window.hp = function(){filter('hp')};
+window.lp = function(){filter('lp')};
+window.ap = function(){filter('ap')};
+window.bph = function(){filter('bph')};
+window.bpl = function(){filter('bpl')};
 
 }());
 
@@ -122,6 +102,8 @@ window.ap = function(){ap()};
         <button onclick="hp()">High-Pass</button><span> Cutoff: 1200, Q: 0.6</span><br>
         <button onclick="lp()">Low-Pass</button><span> Cutoff: 1200, Q: 0.6</span><br>
         <button onclick="ap()">All-Pass</button><span> f0: 300, Q: 0.6</span><br>
+        <button onclick="bpl()">Band-Pass Low</button><span> centerFreq: 250, bandwidth: 1 octave</span><br>
+        <button onclick="bph()">Band-Pass High</button><span> centerFreq: 3333, bandwidth: 1 octave</span><br>
         <canvas id=c width=1000 height=420></canvas>
     </body>
 </html>

--- a/tests/biquad.html
+++ b/tests/biquad.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>audiolib.js | Biquad Filter Test</title>
+        <script src="../lib/audiolib.js"></script>
+        <script>
+(function(){
+    
+var hp, lp, ap;
+
+function plotPCM(buffer, channelCount){
+    var canvas      = document.getElementById('c'),
+        context     = canvas.getContext('2d'),
+        width       = canvas.width,
+        height      = canvas.height,
+        halfHeight  = height/2,
+        waveScale   = 100, // Pixel height of amplitude 1
+        sampleRate  = 44100,
+        plotTime    = 0.01, // Seconds to plot
+        xscale      = width/(sampleRate*plotTime),
+        osc         = new audioLib.Oscillator(sampleRate, 220),
+        osc2        = new audioLib.Oscillator(sampleRate, 3500),
+        lpf         = new audioLib.BiquadFilter.LowPass(sampleRate, 1200, 0.6),
+        apf         = new audioLib.BiquadFilter.AllPass(sampleRate, 300, 0.6),
+        hpf         = new audioLib.BiquadFilter.HighPass(sampleRate, 1200, 0.6);
+     
+    function setup(){
+        context.clearRect ( 0, 0, width, height);
+        // Reference Box, +- 1
+        context.strokeStyle="#33FF33";
+        context.beginPath();
+        context.rect(0,halfHeight-waveScale, width, waveScale*2);
+        context.stroke();
+    
+        // Reference Line, zero
+        context.strokeStyle="#000000";
+        context.beginPath();
+        context.moveTo(0, halfHeight);
+        context.lineTo(width, halfHeight)
+        context.stroke();
+        
+        // Sine wave sum
+        context.beginPath();
+        context.moveTo(0, halfHeight);
+        osc.reset();
+        osc2.reset();
+        for(var i=0, max=sampleRate*plotTime; i<max; i++){
+            
+            context.lineTo(i*xscale, halfHeight + (osc.getMix()+osc2.getMix()) * waveScale);
+            osc.generate();
+            osc2.generate();
+        }
+        context.stroke();
+        
+        osc.reset();
+        osc2.reset();
+        context.strokeStyle="#0000FF";
+        context.beginPath();
+        context.moveTo(0, halfHeight);
+    }
+    setup();
+    
+    hp = function(){
+        // High-Pass Filter
+        setup();
+
+        for(var i=0, max=sampleRate*plotTime; i<max; i++){
+            
+            context.lineTo(i*xscale, halfHeight + hpf.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
+            osc.generate();
+            osc2.generate();
+        } 
+        context.stroke();
+    };
+    
+    lp = function(){
+        // Low-Pass Filter
+        setup();
+
+        for(var i=0, max=sampleRate*plotTime; i<max; i++){
+            
+            context.lineTo(i*xscale, halfHeight + lpf.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
+            osc.generate();
+            osc2.generate();
+        } 
+        context.stroke();
+    };
+    
+    ap = function(){
+        // All-Pass Filter
+        setup();
+
+        for(var i=0, max=sampleRate*plotTime; i<max; i++){
+            
+            context.lineTo(i*xscale, halfHeight + apf.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
+            osc.generate();
+            osc2.generate();
+        } 
+        context.stroke();
+    };
+            
+}
+
+window.onload = function(){
+    setTimeout(function(){
+        plotPCM();
+    }, 2000);
+};
+window.hp = function(){hp()};
+window.lp = function(){lp()};
+window.ap = function(){ap()};
+
+}());
+
+        </script>
+    </head>
+    <body>
+        <h1>Biquad Filter Test</h1>
+        <p>
+            Original signal: sum of 2 sine waves (220Hz and 3500Hz)
+        </p>
+        <button onclick="hp()">High-Pass</button><span> Cutoff: 1200, Q: 0.6</span><br>
+        <button onclick="lp()">Low-Pass</button><span> Cutoff: 1200, Q: 0.6</span><br>
+        <button onclick="ap()">All-Pass</button><span> f0: 300, Q: 0.6</span><br>
+        <canvas id=c width=1000 height=420></canvas>
+    </body>
+</html>

--- a/tests/bitcrusher.html
+++ b/tests/bitcrusher.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>audiolib.js | Bit Crusher Test</title>
+        <script src="../lib/audiolib.js"></script>
+        <script>
+(function(){
+
+function plotPCM(buffer, channelCount){
+    var canvas      = document.getElementById('c'),
+        context     = canvas.getContext('2d'),
+        width       = canvas.width,
+        height      = canvas.height,
+        halfHeight  = height/2,
+        waveScale   = 100, // Pixel height of amplitude 1
+        sampleRate  = 44100,
+        plotTime    = 0.018, // Seconds to plot
+        xscale      = width/(sampleRate*plotTime),
+        osc         = new audioLib.Oscillator(sampleRate, 220),
+        bitcrusher  = new audioLib.BitCrusher(sampleRate, 2);
+    
+    // Reference Box, +- 1
+    context.strokeStyle="#33FF33";
+    context.beginPath();
+    context.rect(0,halfHeight-waveScale, width, waveScale*2);
+    context.stroke();
+
+    // Reference Line, zero
+    context.strokeStyle="#000000";
+    context.beginPath();
+    context.moveTo(0, halfHeight);
+    context.lineTo(width, halfHeight)
+    context.stroke();
+    
+    // Vanilla sine wave
+    context.beginPath();
+    context.moveTo(0, halfHeight);
+    for(var i=0, max=sampleRate*plotTime; i<max; i++){
+        
+        context.lineTo(i*xscale, halfHeight + osc.getMix() * waveScale);
+        osc.generate();
+    }
+    context.stroke();
+    
+    
+    // Bit Crushed Waveform
+    context.strokeStyle="#0000FF";
+    context.beginPath();
+    context.moveTo(0, halfHeight);
+    osc.reset();
+     
+    for(var i=0, max=sampleRate*plotTime; i<max; i++){
+        
+        context.lineTo(i*xscale, halfHeight + bitcrusher.pushSample(osc.getMix()) * waveScale);
+        osc.generate();
+    } 
+    context.stroke();
+    
+}
+
+window.onload = function(){
+    setTimeout(function(){
+        plotPCM();
+    }, 2000);
+};
+
+}());
+
+        </script>
+    </head>
+    <body>
+        <h1>Bit Crusher Test</h1>
+        <p>
+            This test shows 2 waveforms:
+            <ul>
+                <li>Unmodified sine wave at 220Hz in <span style="color:black;">Black</span></li>
+                <li>Signal mangled with <em>audioLib.BitCrusher</em> (bits = 2) in <span style="color:blue;">Blue</span></li>
+            </ul>
+            audioLib.BitCrusher(sampleRate, n) reduces the signal resolution to n bits.
+        </p>
+        <canvas id=c width=1000 height=420></canvas>
+    </body>
+</html>

--- a/tests/compressor.html
+++ b/tests/compressor.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <title>audiolib.js | Compressor Test</title>
         <script src="../lib/audiolib.js"></script>
-        <script src="../js/effects/extra.js"></script>
         <script>
 (function(){
 


### PR DESCRIPTION
Fixed a bug in #20 in the BiquadFilter.reset method..
`self.inputs = self.outputs = [0,0]` wasn't producing expected results

Added new BandPass filter & updated test page with 2 BPF tests
