### PR TITLE
#20 bugfix and new Band-Pass Biquad Filter

### DIFF
--- a/js/effects/biquad.js
+++ b/js/effects/biquad.js
@@ -33,7 +33,8 @@ function BiquadFilter(sampleRate, a0, a1, a2, b1, b2){
     };
     
     self.reset = function(){
-        self.inputs = self.outputs = [0,0];
+        self.inputs = [0,0];
+        self.outputs = [0,0];
     };
 
 }
@@ -104,5 +105,29 @@ BiquadFilter.AllPass = function(sampleRate, f0, Q){
         a0      =  b2,
         a1      =  b1,
         a2      =  b0;
+    return new audioLib.BiquadFilter(sampleRate, b0/a0, b1/a0, b2/a0, a1/a0, a2/a0);
+}
+
+/**
+ * Creates a Biquad Band-Pass Filter Effect
+ * 
+ * @constructor
+ * @this {BiquadFilter}
+ * @param {number} samplerate Sample Rate (hz).
+ * @param {number} centerFreq Center frequency of filter: 0dB gain at center peak
+ * @param {number} bandwidthInOctaves Bandwitdth of the filter (between -3dB points), specified in octaves
+*/
+BiquadFilter.BandPass = function(sampleRate, centerFreq, bandwidthInOctaves){
+    var w0      = 2* Math.PI*centerFreq/sampleRate,
+        cosw0   = Math.cos(w0),
+        sinw0   = Math.sin(w0),
+        toSinh  = Math.log(2)/2 * bandwidthInOctaves * w0/sinw0,
+        alpha   = sinw0*(Math.exp(toSinh) - Math.exp(-toSinh))/2,
+        b0      =  alpha,
+        b1      =  0,
+        b2      = -alpha,
+        a0      =  1 + alpha,
+        a1      = -2*cosw0,
+        a2      =  1 - alpha;
     return new audioLib.BiquadFilter(sampleRate, b0/a0, b1/a0, b2/a0, a1/a0, a2/a0);
 }

--- a/tests/biquad.html
+++ b/tests/biquad.html
@@ -6,7 +6,7 @@
         <script>
 (function(){
     
-var hp, lp, ap;
+var filter;
 
 function plotPCM(buffer, channelCount){
     var canvas      = document.getElementById('c'),
@@ -22,7 +22,10 @@ function plotPCM(buffer, channelCount){
         osc2        = new audioLib.Oscillator(sampleRate, 3500),
         lpf         = new audioLib.BiquadFilter.LowPass(sampleRate, 1200, 0.6),
         apf         = new audioLib.BiquadFilter.AllPass(sampleRate, 300, 0.6),
-        hpf         = new audioLib.BiquadFilter.HighPass(sampleRate, 1200, 0.6);
+        hpf         = new audioLib.BiquadFilter.HighPass(sampleRate, 1200, 0.6),
+        bpfh        = new audioLib.BiquadFilter.BandPass(sampleRate, 3333, 1),
+        bpfl        = new audioLib.BiquadFilter.BandPass(sampleRate, 250, 1),
+        names       = {lp:lpf, hp:hpf, ap:apf, bph:bpfh, bpl:bpfl};
      
     function setup(){
         context.clearRect ( 0, 0, width, height);
@@ -60,39 +63,14 @@ function plotPCM(buffer, channelCount){
     }
     setup();
     
-    hp = function(){
-        // High-Pass Filter
+    filter = function(type, param){
         setup();
-
+        var filter = names[type];
+        filter.reset();
+        
         for(var i=0, max=sampleRate*plotTime; i<max; i++){
             
-            context.lineTo(i*xscale, halfHeight + hpf.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
-            osc.generate();
-            osc2.generate();
-        } 
-        context.stroke();
-    };
-    
-    lp = function(){
-        // Low-Pass Filter
-        setup();
-
-        for(var i=0, max=sampleRate*plotTime; i<max; i++){
-            
-            context.lineTo(i*xscale, halfHeight + lpf.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
-            osc.generate();
-            osc2.generate();
-        } 
-        context.stroke();
-    };
-    
-    ap = function(){
-        // All-Pass Filter
-        setup();
-
-        for(var i=0, max=sampleRate*plotTime; i<max; i++){
-            
-            context.lineTo(i*xscale, halfHeight + apf.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
+            context.lineTo(i*xscale, halfHeight + filter.pushSample((osc.getMix()+osc2.getMix())) * waveScale);
             osc.generate();
             osc2.generate();
         } 
@@ -106,9 +84,11 @@ window.onload = function(){
         plotPCM();
     }, 2000);
 };
-window.hp = function(){hp()};
-window.lp = function(){lp()};
-window.ap = function(){ap()};
+window.hp = function(){filter('hp')};
+window.lp = function(){filter('lp')};
+window.ap = function(){filter('ap')};
+window.bph = function(){filter('bph')};
+window.bpl = function(){filter('bpl')};
 
 }());
 
@@ -122,6 +102,8 @@ window.ap = function(){ap()};
         <button onclick="hp()">High-Pass</button><span> Cutoff: 1200, Q: 0.6</span><br>
         <button onclick="lp()">Low-Pass</button><span> Cutoff: 1200, Q: 0.6</span><br>
         <button onclick="ap()">All-Pass</button><span> f0: 300, Q: 0.6</span><br>
+        <button onclick="bpl()">Band-Pass Low</button><span> centerFreq: 250, bandwidth: 1 octave</span><br>
+        <button onclick="bph()">Band-Pass High</button><span> centerFreq: 3333, bandwidth: 1 octave</span><br>
         <canvas id=c width=1000 height=420></canvas>
     </body>
 </html>


### PR DESCRIPTION
Fixed a bug in #20 in the BiquadFilter.reset method..
`self.inputs = self.outputs = [0,0]` wasn't producing expected results

Added new BandPass filter & updated test page with 2 BPF tests
