### PR TITLE
Resampling bug fix

### DIFF
--- a/js/generation/sampler.js
+++ b/js/generation/sampler.js
@@ -178,7 +178,7 @@ interpolation('linear');
 Sampler.resample	= function(buffer, fromRate /* or speed */, fromFrequency /* or toRate */, toRate, toFrequency){
 	var
 		argc		= arguments.length,
-		speed		= argc === 2 ? fromRate : argc === 3 ? toRate / fromFrequency : toRate / fromRate * toFrequency / fromFrequency,
+		speed		= argc === 2 ? fromRate : argc === 3 ? fromRate / fromFrequency : toRate / fromRate * toFrequency / fromFrequency,
 		l		= buffer.length,
 		length		= Math.ceil(l / speed),
 		newBuffer	= new Float32Array(length),


### PR DESCRIPTION
Was getting NaN errors when trying to resample like so: `Sampler.resample(buffer, 44100, 48000)`

Fixed a typo - if `argc === 3`, then `toRate` is undefined.

Might want to be sure the last possible condition is written correctly too... `toRate / fromRate * toFrequency / fromFrequency` .. should it be from over to? I haven't taken the time to think about it too much.
