### PR TITLE
Freeverb transition to 0.5.0 API

### DIFF
--- a/js/effects/combfilter.js
+++ b/js/effects/combfilter.js
@@ -10,34 +10,52 @@
  * @param {number} damping (Optional) Amount of damping (0.0-1.0). Defaults to 0.2 (Freeverb default)
 */
 function CombFilter(sampleRate, delaySize, feedback, damping){
-	var	self	= this,
-		sample  = 0.0,
-		index	= 0,
-		store	= 0;
+	var	self	= this;
 	self.sampleRate	= sampleRate;
 	self.buffer	= new Float32Array(isNaN(delaySize) ? 1200 : delaySize);
 	self.bufferSize	= self.buffer.length;
-	self.feedback	= isNaN(feedback) ? 0.84 : feedback;
-	self.damping	= isNaN(damping) ? 0.2 : damping;
-
-	self.pushSample	= function(s){
-		sample	= self.buffer[index];
-		store	= sample * (1 - self.damping) + store * self.damping;	// Note: optimizable by storing (1-self.damp) like freeverb (damp2). Would require filter.setDamp(x) rather than filter.damp=x
-		self.buffer[index++] = s + store * self.feedback;
-		if (index >= self.bufferSize) {
-			index = 0;
-		}
-		return sample;
-	};
-	
-	self.getMix = function(){
-		return sample;
-	};
-	
-	self.reset = function(){		
-		index	= 0;
-		store	= 0;
-		sample	= 0.0;
-		self.buffer = new Float32Array(self.bufferSize);
-	};
+	self.feedback	= isNaN(feedback) ? self.feedback : feedback;
+	self.damping	= isNaN(damping) ? self.damping : damping;
+	self.invDamping	= 1 - self.damping;
 }
+
+CombFilter.prototype = {
+	sample:		0.0,
+	index:		0,
+	store:		0,
+
+	feedback:	0.84,
+	damping:	0.2,
+
+	pushSample: function(s){
+		var	self	= this;
+		self.sample	= self.buffer[self.index];
+		self.store	= self.sample * self.invDamping + self.store * self.damping;
+		self.buffer[self.index++] = s + self.store * self.feedback;
+		if (self.index >= self.bufferSize) {
+			self.index = 0;
+		}
+		return self.sample;
+	},
+	getMix: function(){
+		return this.sample;
+	},
+	reset: function(){
+		this.index	= this.store = 0;
+		this.samples	= 0.0;
+		this.buffer	= new Float32Array(this.bufferSize);
+	},
+	setParam: function(param, value){
+		switch (param){
+		case 'damping':
+			console.log(value);
+			this.damping	= value;
+			this.invDamping	= 1 - value;
+			break;
+		default:
+			this[param] = value;
+			break;
+		}
+	}
+
+};

--- a/js/effects/combfilter.js
+++ b/js/effects/combfilter.js
@@ -48,7 +48,6 @@ CombFilter.prototype = {
 	setParam: function(param, value){
 		switch (param){
 		case 'damping':
-			console.log(value);
 			this.damping	= value;
 			this.invDamping	= 1 - value;
 			break;

--- a/js/effects/freeverb.js
+++ b/js/effects/freeverb.js
@@ -66,7 +66,7 @@ Freeverb.prototype = {
 	channelCount: 	2,
 	sample:		[0.0, 0.0],
 
-	wet:		1,
+	wet:		0.6,
 	dry:		0.45,
 	damping:	0.5,
 	roomSize:	0.5,
@@ -79,7 +79,7 @@ Freeverb.prototype = {
 		allPassTuning:		[556, 441, 341, 225],
 		allPassFeedback:	0.5,
 
-		fixedGain:		0.035,
+		fixedGain:		0.015,
 		scaleDamping:		0.4,
 
 		scaleRoom:		0.28,
@@ -161,34 +161,37 @@ Freeverb.prototype = {
  * @param {number} feedback (Optional) Amount of feedback (0.0-1.0). Defaults to 0.5 (Freeverb default)
 */
 Freeverb.AllPassFilter = function(sampleRate, delaySize, feedback){
-	var	self	= this,
-		sample  = 0.0,
-		index	= 0;
+	var	self	= this;
 	self.sampleRate	= sampleRate;
 	self.buffer	= new Float32Array(isNaN(delaySize) ? 500 : delaySize);
 	self.bufferSize	= self.buffer.length;
-	self.feedback	= isNaN(feedback) ? 0.5 : feedback;
-
-	self.pushSample	= function(s){
-		var bufOut		= self.buffer[index];
-		sample			= -s + bufOut;
-		self.buffer[index++]	= s + bufOut * self.feedback;
-		if (index >= self.bufferSize) {
-			index = 0;
-		}
-		return sample;
-	};
-	
-	self.getMix = function(){
-		return sample;
-	};
-	
-	self.reset = function(){		
-		index	= 0;
-		sample	= 0.0;
-		self.buffer = new Float32Array(self.bufferSize);
-	};
+	self.feedback	= isNaN(feedback) ? self.feedback : feedback;
 };
+
+Freeverb.AllPassFilter.prototype = {
+	sample:		0.0,
+	index:		0,
+	feedback:	0.5,
+
+	pushSample: function(s){
+		var	self		= this;
+			bufOut		= self.buffer[self.index];
+		self.sample		= -s + bufOut;
+		self.buffer[self.index++] = s + bufOut * self.feedback;
+		if (self.index >= self.bufferSize) {
+			self.index = 0;
+		}
+		return self.sample;
+	},
+	getMix: function(){
+		return this.sample;
+	},
+	reset: function(){
+		this.index	= 0;
+		this.sample	= 0.0;
+		this.buffer	= new Float32Array(this.bufferSize);
+	}
+}
 
 
 

--- a/js/effects/freeverb.js
+++ b/js/effects/freeverb.js
@@ -4,8 +4,12 @@
  * @constructor
  * @this {Freeverb}
  * @param {number} samplerate Sample Rate (hz).
- * @param {boolean} isRightChannel Controls the addition of stereo spread. Defaults to false.
- * @param {Object} tuning (Optional) Freeverb tuning overwrite object
+ * @param {number} channelCount (Optional)  Channel count. Defaults to 2.
+ * @param {number} wet (Optional)  The gain of the reverb signal output. Defaults to 0.5.
+ * @param {number} dry (Optional)  The gain of the original signal output. Defaults to 0.55.
+ * @param {number} roomSize (Optional)  The size of the simulated reverb area. Defaults to 0.5. (0.0 - 1.0)
+ * @param {number} damping (Optional) Reverberation damping parameter. Defaults to 0.2223. (0.0 - 1.0)
+ * @param {Object} tuningOverride (Optional) Freeverb tuning overwrite object
 */
 function Freeverb(sampleRate, channelCount, wet, dry, roomSize, damping, tuningOverride){
 	var	self		= this;
@@ -37,10 +41,9 @@ function Freeverb(sampleRate, channelCount, wet, dry, roomSize, damping, tuningO
 			combs.push(channel);
 			channel = [];
 		}
-		console.log(self.tuning);
 		return combs;
 	}());
-	self.numCFs	= self.CFs.length;
+	self.numCFs	= self.CFs[0].length;
 	
 	self.APFs	= (function(){
 		var 	apfs	= [],
@@ -58,17 +61,16 @@ function Freeverb(sampleRate, channelCount, wet, dry, roomSize, damping, tuningO
 		}
 		return apfs;
 	}());
-	self.numAPFs	= self.APFs.length;
-	console.log(self);
+	self.numAPFs	= self.APFs[0].length;
 }
 
 Freeverb.prototype = {
 	channelCount: 	2,
 	sample:		[0.0, 0.0],
 
-	wet:		0.6,
-	dry:		0.45,
-	damping:	0.5,
+	wet:		0.5,
+	dry:		0.55,
+	damping:	0.2223,
 	roomSize:	0.5,
 
 	tuning: {
@@ -80,7 +82,7 @@ Freeverb.prototype = {
 		allPassFeedback:	0.5,
 
 		fixedGain:		0.015,
-		scaleDamping:		0.4,
+		scaleDamping:		0.9,
 
 		scaleRoom:		0.28,
 		offsetRoom:		0.7,

--- a/js/effects/freeverb.js
+++ b/js/effects/freeverb.js
@@ -7,92 +7,117 @@
  * @param {boolean} isRightChannel Controls the addition of stereo spread. Defaults to false.
  * @param {Object} tuning (Optional) Freeverb tuning overwrite object
 */
-function Freeverb(sampleRate, isRightChannel, tuning){
-	var	self	= this,
-		sample  = 0.0;
-	tuning		= tuning || Freeverb.tuning;
-	self.sampleRate	= sampleRate;
-	self.spread	= isRightChannel ? tuning.stereospread : 0;
-	self.wet	= 0.5;
-	self.dry	= 0.55;
-	self.inScale	= tuning.fixedgain;
+function Freeverb(sampleRate, channelCount, tuning){
+	var	self		= this;
+	self.sampleRate		= sampleRate;
+	self.channelCount	= channelCount || self.channelCount;
+	self.tuning		= tuning || this.tuning;
+	
+	self.sample	= (function(){
+		var	sample	= [],
+			c;
+		for(c=0; c<self.channelCount; c++){
+			sample[c] = 0.0;
+		}
+		return sample;
+	}());
+
 	self.CFs	= (function(){
 		var 	combs	= [],
-			num	= tuning.numcombs,
-			damp	= tuning.initialdamp * tuning.scaledamp,
-			feed	= tuning.initialroom * tuning.scaleroom + tuning.offsetroom,
-			sizes	= tuning.combs,
-			i;
-		for(i=0; i<num; i++){
-			combs.push(new audioLib.CombFilter(self.sampleRate, sizes[i] + self.spread, feed, damp));
+			channel	= [],
+			num	= self.tuning.numcombs,
+			damp	= self.tuning.initialdamp * self.tuning.scaledamp,
+			feed	= self.tuning.initialroom * self.tuning.scaleroom + self.tuning.offsetroom,
+			sizes	= self.tuning.combs,
+			i, c;
+		for(c=0; c<self.channelCount; c++){
+			for(i=0; i<num; i++){
+				channel.push(new audioLib.CombFilter(self.sampleRate, sizes[i] + c * self.tuning.stereospread, feed, damp));
+			}
+			combs.push(channel);
+			channel = [];
+			console.log(c * self.tuning.stereospread);
 		}
+		console.log(self.tuning);
 		return combs;
 	}());
 	self.numCFs	= self.CFs.length;
 	
 	self.APFs	= (function(){
 		var 	apfs	= [],
-			num	= tuning.numallpasses,
-			feed	= 0.5,
-			sizes	= tuning.allpasses,
-			i;
-		for(i=0; i<num; i++){
-			apfs.push(new Freeverb.AllPassFilter(self.sampleRate, sizes[i] + self.spread, feed));
+			channel	= [],
+			num	= self.tuning.numallpasses,
+			feed	= self.tuning.allpassfb,
+			sizes	= self.tuning.allpasses,
+			i, c;
+		for(c=0; c<self.channelCount; c++){
+			for(i=0; i<num; i++){
+				channel.push(new Freeverb.AllPassFilter(self.sampleRate, sizes[i] + c * self.tuning.stereospread, feed));
+			}
+			apfs.push(channel);
+			channel = [];
 		}
 		return apfs;
 	}());
 	self.numAPFs	= self.APFs.length;
-
-	self.pushSample	= function(s){
-		var	input	= s * self.inScale,
-			output	= 0,
-			i;
-		for(i=0; i < self.numCFs; i++){
-			output += self.CFs[i].pushSample(input);
-		}
-		for(i=0; i < self.numAPFs; i++){
-			output = self.APFs[i].pushSample(output);
-		}
-		sample = output * self.wet + s * self.dry;
-		return sample;
-	};
-	
-	self.getMix = function(){
-		return sample;
-	};
-	
-	self.reset = function(){
-		var	i;		
-		for(i=0; i < self.numCFs; i++){
-			self.CFs[i].reset();
-		}
-		for(i=0; i < self.numAPFs; i++){
-			self.APFs[i].reset();
-		}
-		sample	= 0.0;
-	};
+	console.log(self);
 }
 
-// Tuning from FreeVerb source. Much of this is unused. Will optimize further once stereo effect spec makes progress
-Freeverb.tuning = {
-	numcombs:	8,
-	combs:		[1116, 1188, 1277, 1356, 1422, 1491, 1557, 1617],
-	numallpasses:	4,
-	allpasses:	[556, 441, 341, 225],
-	fixedgain:	0.015,
-	scalewet:	3,
-	scaledry:	2,
-	scaledamp:	0.4,
-	scaleroom:	0.28,
-	offsetroom:	0.7,
-	initialroom:	0.5,
-	initialdamp:	0.5,
-	initialwet:	1/3,
-	initialdry:	0,
-	initialwidth:	1,
-	initialmode:	0,
-	freezemode:	0.5,
-	stereospread:	23
+Freeverb.prototype = {
+	channelCount: 	2,
+	sample:		[0.0, 0.0],
+
+	wet:		0.5,
+	dry:		0.55,
+
+	tuning: {
+		numcombs:	8,
+		combs:		[1116, 1188, 1277, 1356, 1422, 1491, 1557, 1617],
+
+		numallpasses:	4,
+		allpasses:	[556, 441, 341, 225],
+		allpassfb:	0.5,
+
+		fixedgain:	0.015,
+		scaledamp:	0.4,
+		scaleroom:	0.28,
+		offsetroom:	0.7,
+		initialroom:	0.5,
+		initialdamp:	0.5,
+		stereospread:	23
+	},
+
+	pushSample: function(s, channel){
+		var	input	= s * this.tuning.fixedgain,
+			output	= 0,
+			i;
+		for(i=0; i < this.numCFs; i++){
+			output += this.CFs[channel][i].pushSample(input);
+		}
+		for(i=0; i < this.numAPFs; i++){
+			output = this.APFs[channel][i].pushSample(output);
+		}
+		this.sample[channel] = output * this.wet + s * this.dry;
+	},
+
+	getMix: function(channel){
+		return this.sample[channel];
+	},
+
+	reset: function(){
+		var	i;		
+		for(i=0; i < this.numCFs; i++){
+			this.CFs[i].reset();
+		}
+		for(i=0; i < this.numAPFs; i++){
+			this.APFs[i].reset();
+		}
+		for(i=0; i < this.channelCount; i++){
+			this.sample[i] = 0.0;
+		}
+	}
+
+	
 };
 
 /**

--- a/tests/reverb.html
+++ b/tests/reverb.html
@@ -7,7 +7,7 @@
 		<script>
 (function(){
 
-var	sampler, dev, sampleRate, activeEffect,
+var	sampler, dev, sampleRate, reverb, activeEffect,
 	effect = {
 		none: function(s, n){return s;},
 		reverb: function(s, n){

--- a/tests/reverb.html
+++ b/tests/reverb.html
@@ -75,13 +75,13 @@ window.reset	= function(){
 		<label for="f">Frequency</label>
 		<input id="f" value="440"><br>
 		<label for="w">Wet</label>
-		<input id="w" value="1">
+		<input id="w" value="0.5">
 		<label for="d">Dry</label>
-		<input id="d" value="0.45"><span> Note: Wet/Dry do not have to total to 1</span><br>
+		<input id="d" value="0.55"><span> Note: Wet/Dry do not have to total to 1</span><br>
 		<label for="rs">Room Size</label>
-		<input id="rs" value="0.5"><br>
+		<input id="rs" value="0.5"> (0.0 - 1.0) <br>
 		<label for="dmp">Damping</label>
-		<input id="dmp" value="0.5"><br>
+		<input id="dmp" value="0.2223"> (0.0 - 1.0)<br>
 
 		<button onclick="play(document.getElementById('f').value)">Play</button>
 		<button onclick="playReverb(document.getElementById('f').value,document.getElementById('w').value,document.getElementById('d').value,document.getElementById('rs').value,document.getElementById('dmp').value)">Play Reverb</button>

--- a/tests/reverb.html
+++ b/tests/reverb.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<title>audiolib.js | Reverb Test</title>
 		<script src="../lib/audiolib.js"></script>
 		<script src="samples/freeverb.js"></script>
 		<script>
@@ -35,27 +36,35 @@ window.onload	= function(){
 		reverb		= new audioLib.Reverb(sampleRate, 2);
 		
 		var sample = audioLib.PCMData.decode(atob(freeverb.sample));
-		
-		//sample = (sampleRate === 44100) ? sample : audioLib.Sampler.resample(sample, 44100, sampleRate);
-		//sampler.loadWav(atob(freeverb.sample), true);
 		sampler.load(sample, (sampleRate === 44100 ? false : true));
-		//if(sampleRate !== 44100) sampler.load(audioLib.Sampler.resample(sampler.sample, 44100, sampleRate))
+
 	}, 2000);
 };
 
-window.play	= function(frequency, wet, dry){
+window.play	= function(frequency){
 	activeEffect = effect.none;
-	reverb.wet = wet;
-	reverb.dry = dry;
 	console.log(sampler.noteOn(frequency));
-}
+};
 
-window.playReverb	= function(frequency, wet, dry){
-	activeEffect = effect.reverb;
-	reverb.wet = wet;
-	reverb.dry = dry;
+window.playReverb	= function(frequency, wet, dry, roomSize, damping){
+	wet 		= parseFloat(wet);
+	dry 		= parseFloat(dry);
+	roomSize	= parseFloat(roomSize);
+	damping		= parseFloat(damping);
+	activeEffect	= effect.reverb;
+	reverb.setParam('wet', wet);
+	reverb.setParam('dry', dry);
+	if(roomSize !== reverb.roomSize) {
+		reverb.setParam('roomSize', roomSize);
+	}
+	if(damping !== reverb.damping) {
+		reverb.setParam('damping', damping);
+	}
 	console.log(sampler.noteOn(frequency));
-}
+};
+window.reset	= function(){
+	reverb.reset();
+};
 
 }());
 
@@ -64,13 +73,20 @@ window.playReverb	= function(frequency, wet, dry){
 	<body>
 		<h1>Reverb Test</h1>
 		<label for="f">Frequency</label>
-		<input id="f" value="440">
+		<input id="f" value="440"><br>
 		<label for="w">Wet</label>
-		<input id="w" value="0.5">
+		<input id="w" value="1">
 		<label for="d">Dry</label>
-		<input id="d" value="0.55"><br>
-		<button onclick="play(document.getElementById('f').value,document.getElementById('w').value,document.getElementById('d').value)">Play</button>
-		<button onclick="playReverb(document.getElementById('f').value,document.getElementById('w').value,document.getElementById('d').value)">Play Reverb</button>
-		<p>Be patient, sample may take a few seconds to load. Note: Wet/Dry do not have to total to 1.</p>
+		<input id="d" value="0.45"><span> Note: Wet/Dry do not have to total to 1</span><br>
+		<label for="rs">Room Size</label>
+		<input id="rs" value="0.5"><br>
+		<label for="dmp">Damping</label>
+		<input id="dmp" value="0.5"><br>
+
+		<button onclick="play(document.getElementById('f').value)">Play</button>
+		<button onclick="playReverb(document.getElementById('f').value,document.getElementById('w').value,document.getElementById('d').value,document.getElementById('rs').value,document.getElementById('dmp').value)">Play Reverb</button>
+		<p>Be patient, sample may take a few seconds to load.</p><br><br>
+		<span>Did you set roomSize > 1? Fun huh?</span><br>
+		<button onclick="reset()">Reverb reset</button>
 	</body>
 </html>

--- a/tests/reverb.html
+++ b/tests/reverb.html
@@ -6,12 +6,15 @@
 		<script>
 (function(){
 
-var	sampler, dev, sampleRate, reverb, apply,
+var	sampler, dev, sampleRate, activeEffect,
 	effect = {
 		none: function(s, n){return s;},
-		reverb: function(s, n){return reverb[n].pushSample(s);}
+		reverb: function(s, n){
+			reverb.pushSample(s, n);
+			return reverb.getMix(n);
+		}
 	};
-apply = effect.none;
+activeEffect = effect.none;
 
 function audioProcess(buffer, channelCount){
 	var	l	= buffer.length,
@@ -19,7 +22,7 @@ function audioProcess(buffer, channelCount){
 	for (i=0; i<l; i+=channelCount){
 		sampler.generate();
 		for (n=0; n<channelCount; n++){
-			buffer[n + i] = apply(sampler.getMix(n), n);
+			buffer[n + i] = activeEffect(sampler.getMix(n), n);
 		}
 	}
 }
@@ -29,7 +32,7 @@ window.onload	= function(){
 		dev		= audioLib.AudioDevice(audioProcess, 2);
 		sampleRate	= dev.sampleRate;
 		sampler		= new audioLib.Sampler(sampleRate);
-		reverb		= [new audioLib.Reverb(sampleRate, false), new audioLib.Reverb(sampleRate, true)];
+		reverb		= new audioLib.Reverb(sampleRate, 2);
 		
 		var sample = audioLib.PCMData.decode(atob(freeverb.sample));
 		
@@ -41,16 +44,16 @@ window.onload	= function(){
 };
 
 window.play	= function(frequency, wet, dry){
-	apply = effect.none;
-	reverb[0].wet = reverb[1].wet = wet;
-	reverb[0].dry = reverb[1].dry = dry;
+	activeEffect = effect.none;
+	reverb.wet = wet;
+	reverb.dry = dry;
 	console.log(sampler.noteOn(frequency));
 }
 
 window.playReverb	= function(frequency, wet, dry){
-	apply = effect.reverb;
-	reverb[0].wet = reverb[1].wet = wet;
-	reverb[0].dry = reverb[1].dry = dry;
+	activeEffect = effect.reverb;
+	reverb.wet = wet;
+	reverb.dry = dry;
 	console.log(sampler.noteOn(frequency));
 }
 


### PR DESCRIPTION
Linked with #8

Found the bug in there.. now working nicely.
Test now includes roomSize / damping parameters via overridden setParam

Tweaked the damping scale parameter so that everything works on a 0.0-1.0 basis (was not the case in freeverb).

Reorganized the CombFilter and the Freeverb.AllPassFilter to be more memory-efficient, but I need to learn the exact speed effects of this.param vs self.param vs local param.. maybe you have some input here?
