### PR TITLE
Trailing Comma Fix for Closure Compiler

### DIFF
--- a/src/api-automation.js
+++ b/src/api-automation.js
@@ -22,7 +22,7 @@ AutomationClass.prototype = {
 		} else {
 			this.mode	= this.mode || Automation.modes[this.type];
 		}
-	},
+	}
 };
 
 /**
@@ -174,7 +174,7 @@ Automation.modes = {
 	},
 	absoluteAssignment: function (fx, param, value) {
 		fx.setParam(param, Math.abs(value));
-	},
+	}
 };
 
 Automation.__constructror = AutomationClass;

--- a/src/api-buffer-effect.js
+++ b/src/api-buffer-effect.js
@@ -60,5 +60,5 @@ BufferEffect.prototype = {
 		for (i=0; i<l; i++) {
 			this.effects[i].setParam(param, value);
 		}
-	},
+	}
 };

--- a/src/api-codec.js
+++ b/src/api-codec.js
@@ -12,7 +12,7 @@ function Codec (name, codec) {
 				data:		this.join(),
 				sampleRate:	this.boundTo.sampleRate,
 				channelCount:	this.boundTo.channelCount,
-				bytesPerSample:	bytesPerSample,
+				bytesPerSample:	bytesPerSample
 			});
 		};
 	}

--- a/src/api-effect.js
+++ b/src/api-effect.js
@@ -102,5 +102,5 @@ EffectClass.prototype = {
  *
  * @method Effect
 */
-	reset: function () {},
+	reset: function () {}
 };

--- a/src/api-generator.js
+++ b/src/api-generator.js
@@ -113,5 +113,5 @@ GeneratorClass.prototype = {
  *
  * @method Generator
 */
-	reset: function () {},
+	reset: function () {}
 };

--- a/src/api-plugin.js
+++ b/src/api-plugin.js
@@ -2,7 +2,7 @@ function Plugin (name, plugin) {
 	Plugin[name] = plugin;
 	Plugin._pluginList.push({
 		plugin: plugin,
-		name:	name,
+		name:	name
 	});
 }
 

--- a/src/controls/adsr.js
+++ b/src/controls/adsr.js
@@ -116,5 +116,5 @@ ADSREnvelope.prototype = {
 				this.state	= 0;
 			}
 		}
-	],
+	]
 };

--- a/src/controls/stepsequencer.js
+++ b/src/controls/stepsequencer.js
@@ -73,5 +73,5 @@ StepSequencer.prototype = {
 */
 	triggerGate: function () {
 		this.phase = 0;
-	},
+	}
 };

--- a/src/controls/uicontrol.js
+++ b/src/controls/uicontrol.js
@@ -50,12 +50,12 @@ UIControl.prototype = {
 	setValue: function (value) {
 		this.schedule.push({
 			v:	value,
-			t:	~~((+new Date - this.clock) / 1000 * this.sampleRate),
+			t:	~~((+new Date - this.clock) / 1000 * this.sampleRate)
 		});
 	},
 
 	reset: function (value) {
 		this.value	= isNaN(value) ? this.value : value;
 		this.clock	= +new Date;
-	},
+	}
 };

--- a/src/effects/combfilter.js
+++ b/src/effects/combfilter.js
@@ -60,5 +60,5 @@ CombFilter.prototype = {
 			this[param] = value;
 			break;
 		}
-	},
+	}
 };

--- a/src/effects/convolution.js
+++ b/src/effects/convolution.js
@@ -53,5 +53,5 @@ This is a very suboptimal implementation...
 		}
 
 		this[param] = value;
-	},
+	}
 };

--- a/src/effects/freeverb.js
+++ b/src/effects/freeverb.js
@@ -183,7 +183,7 @@ Freeverb.Tuning.prototype = {
 	scaleRoom:		0.28,
 	offsetRoom:		0.7,
 	
-	stereoSpread:		23,
+	stereoSpread:		23
 };
 
 /**
@@ -229,5 +229,5 @@ Freeverb.AllPassFilter.prototype = {
 		this.index	= 0;
 		this.sample	= 0.0;
 		this.buffer	= new Float32Array(this.bufferSize);
-	},
+	}
 }

--- a/src/effects/gain.js
+++ b/src/effects/gain.js
@@ -36,5 +36,5 @@ GainController.prototype = {
 */
 	getMix: function () {
 		return this.sample;
-	},
+	}
 };

--- a/src/generators/noise.js
+++ b/src/generators/noise.js
@@ -93,5 +93,5 @@ Noise.prototype = {
 		var	w	= this.white();
 		this.brownQ	= (this.q1 * w + this.q0 * this.brownQ);
 		return 6.2 * this.brownQ;
-	},
+	}
 };

--- a/src/generators/oscillator.js
+++ b/src/generators/oscillator.js
@@ -174,7 +174,7 @@ proto = Oscillator.prototype = {
 		return audioLib.Sink.interpolate(this.waveTable, this._p * this.waveTable.length);
 	},
 
-	waveShapes: [],
+	waveShapes: []
 };
 
 for (i=0; i<waveshapeNames.length; i++) {

--- a/src/generators/sampler.js
+++ b/src/generators/sampler.js
@@ -117,5 +117,5 @@ Sampler.prototype = {
 		self.samples	= samples;
 		self.data	= data;
 		self.sampleSize = samples[0].length;
-	},
+	}
 };

--- a/src/io/sink.js
+++ b/src/io/sink.js
@@ -106,7 +106,7 @@ SinkClass.prototype = Sink.prototype = {
 
 		this.isReady = true;
 		this.emit('ready', []);
-	},
+	}
 };
 
 /**
@@ -224,7 +224,7 @@ EventEmitter.prototype = {
 			this._listeners[name].length || delete this._listeners[name];
 		}
 		return this;
-	},
+	}
 };
 
 Sink.EventEmitter = EventEmitter;
@@ -270,24 +270,24 @@ SinkError.prototype.toString = function () {
 
 SinkError[0x01] = {
 	message: 'No such error code.',
-	explanation: 'The error code does not exist.',
+	explanation: 'The error code does not exist.'
 };
 SinkError[0x02] = {
 	message: 'No audio sink available.',
-	explanation: 'The audio device may be busy, or no supported output API is available for this browser.',
+	explanation: 'The audio device may be busy, or no supported output API is available for this browser.'
 };
 
 SinkError[0x10] = {
 	message: 'Buffer underflow.',
-	explanation: 'Trying to recover...',
+	explanation: 'Trying to recover...'
 };
 SinkError[0x11] = {
 	message: 'Critical recovery fail.',
-	explanation: 'The buffer underflow has reached a critical point, trying to recover, but will probably fail anyway.',
+	explanation: 'The buffer underflow has reached a critical point, trying to recover, but will probably fail anyway.'
 };
 SinkError[0x12] = {
 	message: 'Buffer size too large.',
-	explanation: 'Unable to allocate the buffer due to excessive length, please try a smaller buffer. Buffer size should probably be smaller than the sample rate.',
+	explanation: 'Unable to allocate the buffer due to excessive length, please try a smaller buffer. Buffer size should probably be smaller than the sample rate.'
 };
 
 Sink.Error = SinkError;
@@ -518,7 +518,7 @@ Sink.sinks('audiodata', function () {
 
 	getPlaybackTime: function () {
 		return this._audio.mozCurrentSampleOffset() / this.channelCount;
-	},
+	}
 }, false, true);
 
 Sink.sinks.moz = Sink.sinks.audiodata;
@@ -566,7 +566,7 @@ sinks('wav', function () {
 				data:		soundData,
 				sampleRate:	self.sampleRate,
 				channelCount:	self.channelCount,
-				bytesPerSample:	self.quality,
+				bytesPerSample:	self.quality
 			})
 		));
 
@@ -583,7 +583,7 @@ sinks('wav', function () {
 	getPlaybackTime: function () {
 		var audio = this._audio;
 		return (audio.currentFrame ? audio.currentFrame.currentTime * this.sampleRate : 0) + audio.samples;
-	},
+	}
 });
 
 function wavAudio () {
@@ -618,7 +618,7 @@ wavAudio.prototype = {
 		this.nextFrame.addEventListener('ended', this._onended, true);
 
 		this.hasNextFrame = true;
-	},
+	}
 };
 
 sinks.wav.wavAudio = wavAudio;
@@ -646,7 +646,7 @@ Sink.sinks('dummy', function () {
 	kill: function () {
 		this._kill();
 		this.emit('kill');
-	},
+	}
 }, true);
 
 }(this.Sink));
@@ -714,7 +714,7 @@ sinks('webaudio', function (readFn, channelCount, bufferSize, sampleRate) {
 
 	getPlaybackTime: function () {
 		return this._context.currentTime * this.sampleRate;
-	},
+	}
 }, false, true);
 
 sinks.webkit = sinks.webaudio;
@@ -829,7 +829,7 @@ Sink.sinks('worker', function () {
 		this.bufferSize		= b.length * this.channelCount;
 		this.ready		= true;
 		this.emit('ready', []);
-	},
+	}
 });
 
 }(this.Sink));
@@ -1153,7 +1153,7 @@ Proxy.prototype = {
 		this.offset = 0;
 		Sink.memcpy(this.zeroBuffer, 0, this.buffer, 0);
 		this.emit('audioprocess', [this.buffer, this.channelCount]);
-	},
+	}
 };
 
 Sink.Proxy = Proxy;
@@ -1484,7 +1484,7 @@ Recording.prototype = {
 			bufPos += buffers[i].length;
 		}
 		return newArray;
-	},
+	}
 };
 
 Sink.Recording = Recording;

--- a/src/processors/amplitude.js
+++ b/src/processors/amplitude.js
@@ -42,5 +42,5 @@ Amplitude.prototype = {
 */
 	getMix: function () {
 		return this.sample;
-	},
+	}
 };

--- a/src/processors/audioprocessingunit.js
+++ b/src/processors/audioprocessingunit.js
@@ -31,5 +31,5 @@ AudioProcessingUnit.prototype = {
 		this.bufferSize	= isNaN(bufferSize) ? this.bufferSize : bufferSize;
 		this.buffer	= new Float32Array(this.bufferSize);
 		this.bufferPos	= -1;
-	},
+	}
 };

--- a/src/processors/fourier.js
+++ b/src/processors/fourier.js
@@ -69,7 +69,7 @@ FourierTransform.prototype = {
 
 			spectrum[i] = mag;
 		}
-	},
+	}
 };
 
 return FourierTransform;


### PR DESCRIPTION
Removed meaningless trailing commas so Closure wouldn't complain when minifying! Those commas I removed aren't officially supported by JavaScript, so it may be a good idea for compatibility to keep the closure errors at bay!
