### PR TITLE
Try unprefixed APIs first.

### DIFF
--- a/src/io/sink.js
+++ b/src/io/sink.js
@@ -296,8 +296,8 @@ Sink.Error = SinkError;
 (function (Sink) {
 
 var	BlobBuilder	= typeof window === 'undefined' ? undefined :
-	window.MozBlobBuilder || window.WebKitBlobBuilder || window.MSBlobBuilder || window.OBlobBuilder || window.BlobBuilder,
-	URL		= typeof window === 'undefined' ? undefined : (window.MozURL || window.webkitURL || window.MSURL || window.OURL || window.URL);
+	window.BlobBuilder || window.MozBlobBuilder || window.WebKitBlobBuilder || window.MSBlobBuilder || window.OBlobBuilder,
+	URL		= typeof window === 'undefined' ? undefined : (window.URL || window.MozURL || window.webkitURL || window.MSURL || window.OURL);
 
 /**
  * Creates an inline worker using a data/blob URL, if possible.


### PR DESCRIPTION
Firefox nightlies throw warnings every time I use audiolib.js since MozBlobBuild is now deprecated.
